### PR TITLE
feat(cli): add --help and --version options to main command

### DIFF
--- a/.changeset/wild-jeans-guess.md
+++ b/.changeset/wild-jeans-guess.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': minor
+---
+
+Add --help and --version options to main command

--- a/packages/cli/src/get-package-info.ts
+++ b/packages/cli/src/get-package-info.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+type PackageInfo = {
+  version: string;
+};
+
+export const getPackageInfo = async () => {
+  const packageInfoPath = fileURLToPath(new URL('../package.json', import.meta.url));
+
+  try {
+    const content = await fs.readFile(packageInfoPath, 'utf8');
+    const packageJson: unknown = JSON.parse(content);
+
+    if (
+      typeof packageJson === 'object' &&
+      packageJson &&
+      'version' in packageJson &&
+      typeof packageJson.version === 'string'
+    ) {
+      return packageJson as PackageInfo;
+    }
+  } catch {
+    // ignore
+  }
+
+  throw new Error(`Could not read package info from: ${packageInfoPath}`);
+};


### PR DESCRIPTION
This adds the `--help` and `--version` options to the main command, i.e. when no other Emigrate command is specified