### PR TITLE
fix: revert usage of `bun` key in package.json `exports`

### DIFF
--- a/.changeset/ninety-files-doubt.md
+++ b/.changeset/ninety-files-doubt.md
@@ -1,0 +1,10 @@
+---
+'@emigrate/plugin-generate-js': patch
+'@emigrate/reporter-pino': patch
+'@emigrate/plugin-tools': patch
+'@emigrate/storage-fs': patch
+'@emigrate/postgres': patch
+'@emigrate/mysql': patch
+---
+
+Don't use the `bun` key in `exports` as that would mean we have to include both built files and source files in each package, which is a bit wasteful. Maybe reconsider in the future if we can package only source files.

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -10,7 +10,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }

--- a/packages/plugin-generate-js/package.json
+++ b/packages/plugin-generate-js/package.json
@@ -10,7 +10,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }

--- a/packages/plugin-tools/package.json
+++ b/packages/plugin-tools/package.json
@@ -10,7 +10,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -10,7 +10,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }

--- a/packages/reporter-pino/package.json
+++ b/packages/reporter-pino/package.json
@@ -10,7 +10,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }

--- a/packages/storage-fs/package.json
+++ b/packages/storage-fs/package.json
@@ -10,7 +10,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }


### PR DESCRIPTION
Currently we only include the `dist` folder in the published packages so the `bun` key in `exports` pointed to non-existing files. Instead of publishing the `src` folder as well, which is a bit wasteful as we still have to publish the `dist` folder for NodeJS, we revert the change to the package.json files.