### PR TITLE
feat(cli): rename extension short option from `-e` to `-x`

### DIFF
--- a/.changeset/sharp-eggs-poke.md
+++ b/.changeset/sharp-eggs-poke.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': minor
+---
+
+BREAKING CHANGE: Rename the `extension` short CLI option from `-e` to `-x` in preparation for an upcoming option that will take its place

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ bun add @emigrate/cli
 Create a new migration:
 
 ```bash
-npx emigrate new -d migrations -e .js create some fancy table
+npx emigrate new -d migrations create some fancy table
 # or
-pnpm emigrate new -d migrations -e .js create some fancy table
+pnpm emigrate new -d migrations create some fancy table
 # or
-yarn emigrate new -d migrations -e .js create some fancy table
+yarn emigrate new -d migrations create some fancy table
 # or
-bunx --bun emigrate new -d migrations -e .js create some fancy table
+bunx --bun emigrate new -d migrations create some fancy table
 ```
 
 Will create a new empty JavaScript migration file with the name "YYYYMMDDHHmmssuuu_create_some_fancy_table.js" in the `migrations` directory.

--- a/docs/src/content/docs/commands/new.mdx
+++ b/docs/src/content/docs/commands/new.mdx
@@ -74,11 +74,15 @@ The directory where the migration files are located. The given path should be ab
 
 The template file to use for generating the migration file. The given path should be absolute or relative to the current working directory.
 
-The template can contain a `{{name}}` placeholder which will be replaced with the migration name provided to the command. The generated file will have the same extension as the template file, unless the [`--extension`](#-e---extension-ext) option is used.
+The template can contain a `{{name}}` placeholder which will be replaced with the migration name provided to the command. The generated file will have the same extension as the template file, unless the [`--extension`](#-x---extension-ext) option is used.
 
-### `-e`, `--extension <ext>`
+### `-x`, `--extension <ext>`
 
 The extension to use for the migration file. Unless the [`--template`](#-t---template-path) option is also specified the file will be empty.
+
+If both the `--template` and `--extension` options are specified, the extension will override the template file extension.
+
+**Example:** `--extension .sql` will generate a file with the `.sql` extension.
 
 ### `-p`, `--plugin <name>`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,6 +2,8 @@
 
 Emigrate is a tool for managing database migrations. It is designed to be simple yet support advanced setups, modular and extensible.
 
+📖 Read the [documentation](https://emigrate.dev) for more information!
+
 ## Installation
 
 Install the Emigrate CLI in your project:
@@ -21,7 +23,13 @@ bun add @emigrate/cli
 Create a new migration:
 
 ```bash
-emigrate new -d migrations -e .js create some fancy table
+npx emigrate new -d migrations create some fancy table
+# or
+pnpm emigrate new -d migrations create some fancy table
+# or
+yarn emigrate new -d migrations create some fancy table
+# or
+bunx --bun emigrate new -d migrations create some fancy table
 ```
 
 Will create a new empty JavaScript migration file with the name "YYYYMMDDHHmmssuuu_create_some_fancy_table.js" in the `migrations` directory.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -123,7 +123,7 @@ const newMigration: Action = async (args) => {
       },
       extension: {
         type: 'string',
-        short: 'e',
+        short: 'x',
       },
       plugin: {
         type: 'string',
@@ -157,7 +157,7 @@ Options:
   -p, --plugin      The plugin(s) to use (can be specified multiple times)
   -t, --template    A template file to use as contents for the new migration file
                     (if the extension option is not provided the template file's extension will be used)
-  -e, --extension   The extension to use for the new migration file
+  -x, --extension   The extension to use for the new migration file
                     (if no template or plugin is provided an empty migration file will be created with the given extension)
   --color           Force color output (this option is passed to the reporter)
   --no-color        Disable color output (this option is passed to the reporter)
@@ -168,8 +168,8 @@ Examples:
 
   emigrate new -d src/migrations -t migration-template.js create users table
   emigrate new --directory ./migrations --plugin @emigrate/postgres create_users_table
-  emigrate new -d ./migrations -e .sql create_users_table
-  emigrate new -d ./migrations -t .migration-template -e .sql "drop some table"
+  emigrate new -d ./migrations -x .sql create_users_table
+  emigrate new -d ./migrations -t .migration-template -x .sql "drop some table"
 `;
 
   if (values.help) {


### PR DESCRIPTION
BREAKING CHANGE: if you've been using the `-e` short option you should change it to `-x` or use the long option name `--extension`