### PR TITLE
fix(cli): add --limit, --from, --to and --no-execution options to the "up" command

### DIFF
--- a/.changeset/beige-bottles-tie.md
+++ b/.changeset/beige-bottles-tie.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': minor
+---
+
+Add support for the --no-execution option to the "up" command to be able to log migrations as successful without actually running them. Can for instance be used for baselining a database or logging manually run migrations as successful.

--- a/.changeset/grumpy-files-heal.md
+++ b/.changeset/grumpy-files-heal.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': patch
+---
+
+Clarify which cli options that needs parameters

--- a/.changeset/quiet-ravens-sleep.md
+++ b/.changeset/quiet-ravens-sleep.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': minor
+---
+
+Add --from and --to CLI options to control which migrations to include or skip when executing migrations.

--- a/.changeset/sharp-buses-draw.md
+++ b/.changeset/sharp-buses-draw.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': minor
+---
+
+Add --limit option to the "up" command, for limiting the number of migrations to run

--- a/.changeset/smart-ducks-cheer.md
+++ b/.changeset/smart-ducks-cheer.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': patch
+---
+
+Use better wording in the header in the console output from the default reporter

--- a/.changeset/stupid-kings-battle.md
+++ b/.changeset/stupid-kings-battle.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/docs': minor
+---
+
+Add first version of the [Baseline guide](https://emigrate.dev/guides/baseline)

--- a/.changeset/unlucky-seals-camp.md
+++ b/.changeset/unlucky-seals-camp.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/docs': minor
+---
+
+Document the new --limit, --from and --to options for the ["up" command](https://emigrate.dev/commands/up/)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Options:
   --dry                   List the pending migrations that would be run without actually running them
   --color                 Force color output (this option is passed to the reporter)
   --no-color              Disable color output (this option is passed to the reporter)
+  --no-execution          Mark the migrations as executed and successful without actually running them,
+                          which is useful if you want to mark migrations as successful after running them manually
 
 Examples:
 
@@ -72,6 +74,7 @@ Examples:
   emigrate up -d ./migrations -s mysql --import dotenv/config
   emigrate up --limit 1
   emigrate up --to 20231122120529381_some_migration_file.js
+  emigrate up --to 20231122120529381_some_migration_file.js --no-execution
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -41,6 +41,41 @@ bun add @emigrate/cli
 
 ## Usage
 
+```text
+Usage: emigrate up [options]
+
+Run all pending migrations
+
+Options:
+
+  -h, --help              Show this help message and exit
+  -d, --directory <path>  The directory where the migration files are located (required)
+  -i, --import <module>   Additional modules/packages to import before running the migrations (can be specified multiple times)
+                          For example if you want to use Dotenv to load environment variables or when using TypeScript
+  -s, --storage <name>    The storage to use for where to store the migration history (required)
+  -p, --plugin <name>     The plugin(s) to use (can be specified multiple times)
+  -r, --reporter <name>   The reporter to use for reporting the migration progress
+  -l, --limit <count>     Limit the number of migrations to run
+  -f, --from <name>       Start running migrations from the given migration name, the given name doesn't need to exist
+                          and is compared in lexicographical order
+  -t, --to <name>         Skip migrations after the given migration name, the given name doesn't need to exist
+                          and is compared in lexicographical order
+  --dry                   List the pending migrations that would be run without actually running them
+  --color                 Force color output (this option is passed to the reporter)
+  --no-color              Disable color output (this option is passed to the reporter)
+
+Examples:
+
+  emigrate up --directory src/migrations -s fs
+  emigrate up -d ./migrations --storage @emigrate/mysql
+  emigrate up -d src/migrations -s postgres -r json --dry
+  emigrate up -d ./migrations -s mysql --import dotenv/config
+  emigrate up --limit 1
+  emigrate up --to 20231122120529381_some_migration_file.js
+```
+
+### Examples
+
 Create a new migration:
 
 ```bash

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -105,13 +105,17 @@ export default defineConfig({
               label: 'Using TypeScript',
               link: '/guides/typescript/',
             },
+            {
+              label: 'Baseline',
+              link: '/guides/baseline/',
+            },
           ],
         },
         {
           label: 'Plugins',
           items: [
             {
-              label: 'Introduction',
+              label: 'Plugins Introduction',
               link: '/plugins/',
             },
             {
@@ -119,7 +123,7 @@ export default defineConfig({
               collapsed: true,
               items: [
                 {
-                  label: 'Introduction',
+                  label: 'Storage Plugins',
                   link: '/plugins/storage/',
                 },
                 {
@@ -141,7 +145,7 @@ export default defineConfig({
               collapsed: true,
               items: [
                 {
-                  label: 'Introduction',
+                  label: 'Loader Plugins',
                   link: '/plugins/loaders/',
                 },
                 {
@@ -163,7 +167,7 @@ export default defineConfig({
               collapsed: true,
               items: [
                 {
-                  label: 'Introduction',
+                  label: 'Reporters',
                   link: '/plugins/reporters/',
                 },
                 {
@@ -181,7 +185,7 @@ export default defineConfig({
               collapsed: true,
               items: [
                 {
-                  label: 'Introduction',
+                  label: 'Generator Plugins',
                   link: '/plugins/generators/',
                 },
                 {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@emigrate/docs",
   "private": true,
-  "publishConfig": {
-    "access": "public"
-  },
   "type": "module",
   "version": "0.0.1",
   "scripts": {

--- a/docs/src/content/docs/commands/up.mdx
+++ b/docs/src/content/docs/commands/up.mdx
@@ -146,3 +146,8 @@ For example, if you want to use the `emigrate-reporter-somereporter` package, yo
 ### `--color`, `--no-color`
 
 Force enable/disable colored output, option is passed to the reporter which should respect it.
+
+### `--no-execution`
+
+Mark the migrations as executed and successful without actually running them,
+which is useful if you want to mark migrations as successful after running them manually

--- a/docs/src/content/docs/commands/up.mdx
+++ b/docs/src/content/docs/commands/up.mdx
@@ -73,6 +73,24 @@ and "skipped" for the migrations that also haven't been run but won't because of
 
 The directory where the migration files are located. The given path should be absolute or relative to the current working directory.
 
+### `-f`, `--from <name>`
+
+The name of the migration to start from. This can be used to run only a subset of the pending migrations.
+
+The given migration name does not need to exist and is compared in lexicographical order with the migration names, so it can be a prefix of a migration name or similar.
+
+Can be combined with `--dry` which will show "pending" for the migrations that would be run if not in dry-run mode,
+and "skipped" for the migrations that also haven't been run but won't because of the set "from".
+
+### `-t`, `--to <name>`
+
+The name of the migration to end at. This can be used to run only a subset of the pending migrations.
+
+The given migration name does not need to exist and is compared in lexicographical order with the migration names, so it can be a prefix of a migration name or similar.
+
+Can be combined with `--dry` which will show "pending" for the migrations that would be run if not in dry-run mode,
+and "skipped" for the migrations that also haven't been run but won't because of the set "to".
+
 ### `-i`, `--import <module>`
 
 A module to import before running the migrations. This option can be specified multiple times.

--- a/docs/src/content/docs/commands/up.mdx
+++ b/docs/src/content/docs/commands/up.mdx
@@ -64,6 +64,11 @@ Show command help and exit
 
 List the pending migrations that would be run without actually running them
 
+### `-l, --limit <count>`
+
+Limit the number of migrations to run. Can be combined with `--dry` which will show "pending" for the migrations that would be run if not in dry-run mode,
+and "skipped" for the migrations that also haven't been run but won't because of the set limit.
+
 ### `-d`, `--directory <path>`
 
 The directory where the migration files are located. The given path should be absolute or relative to the current working directory.

--- a/docs/src/content/docs/commands/up.mdx
+++ b/docs/src/content/docs/commands/up.mdx
@@ -151,3 +151,7 @@ Force enable/disable colored output, option is passed to the reporter which shou
 
 Mark the migrations as executed and successful without actually running them,
 which is useful if you want to mark migrations as successful after running them manually
+
+:::tip
+See the <Link href="/guides/baseline/">Baseline guide</Link> for example usage of the `--no-execution` option
+:::

--- a/docs/src/content/docs/guides/baseline.mdx
+++ b/docs/src/content/docs/guides/baseline.mdx
@@ -1,0 +1,255 @@
+---
+title: Baseline
+description: A guide on how to baseline an existing database at a specific version
+---
+
+import { Tabs, TabItem, LinkCard } from '@astrojs/starlight/components';
+import Link from '@components/Link.astro';
+
+A common scenario is to have an existing database that you want to start managing with Emigrate. This is called baselining.
+
+## Baselining an existing database schema
+
+Let's assume you have a PostgreSQL database with the following schema:
+
+```sql
+CREATE TABLE public.users (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE public.posts (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES public.users(id),
+    title VARCHAR(255) NOT NULL,
+    body TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+<LinkCard
+  href="../../plugins/storage/postgres/"
+  title="PostgreSQL Storage Plugin"
+  description="See how to configure the PostgreSQL storage plugin here..."
+  />
+
+<LinkCard
+  href="../../plugins/storage/"
+  title="Storage Plugins"
+  description="Learn more about storage plugins here..."
+  />
+
+### Create a baseline migration
+
+You can baseline this database by first creating a baseline migration (here we name it "baseline"):
+
+<Tabs>
+  <TabItem label="npm">
+    ```bash
+    npx emigrate new --plugin postgres baseline
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm emigrate new --plugin postgres baseline
+    ```
+  </TabItem>
+  <TabItem label="yarn">
+    ```bash
+    yarn emigrate new --plugin postgres baseline
+    ```
+  </TabItem>
+  <TabItem label="bun">
+    ```bash
+    bunx --bun emigrate new --plugin postgres baseline
+    ```
+  </TabItem>
+  <TabItem label="deno">
+    ```json title="package.json" {3,6}
+    {
+      "scripts": {
+        "emigrate": "emigrate"
+      },
+      "dependencies": {
+        "@emigrate/cli": "*"
+      }
+    }
+    ```
+
+    ```bash
+    deno task emigrate new --plugin postgres baseline
+    ```
+  </TabItem>
+</Tabs>
+
+Which will generate an empty migration file in your migration directory:
+
+```sql title="migrations/20240118123456789_baseline.sql"
+-- Migration: baseline
+
+```
+
+You can then add the SQL statements for your database schema to this migration file:
+
+```sql title="migrations/20240118123456789_baseline.sql"
+-- Migration: baseline
+CREATE TABLE public.users (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE public.posts (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES public.users(id),
+    title VARCHAR(255) NOT NULL,
+    body TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+### Log the baseline migration
+
+For new environments this baseline migration will automatically be run when you run <Link href="/commands/up/">`emigrate up`</Link>.
+For any existing environments you will need to run `emigrate up` with the <Link href="/commands/up/#--no-execution">`--no-execution`</Link> flag to prevent the migration from being executed and only log the migration:
+
+<Tabs>
+  <TabItem label="npm">
+    ```bash
+    npx emigrate up --no-execution
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm emigrate up --no-execution
+    ```
+  </TabItem>
+  <TabItem label="yarn">
+    ```bash
+    yarn emigrate up --no-execution
+    ```
+  </TabItem>
+  <TabItem label="bun">
+    ```bash
+    bunx --bun emigrate up --no-execution
+    ```
+  </TabItem>
+  <TabItem label="deno">
+    ```json title="package.json" {3,6}
+    {
+      "scripts": {
+        "emigrate": "emigrate"
+      },
+      "dependencies": {
+        "@emigrate/cli": "*"
+      }
+    }
+    ```
+
+    ```bash
+    deno task emigrate up --no-execution
+    ```
+  </TabItem>
+</Tabs>
+
+In case you have already added more migration files to your migration directory you can limit the "up" command to just log the baseline migration by specifying the <Link href="/commands/up/#-t---to-name">`--to`</Link> option:
+
+<Tabs>
+  <TabItem label="npm">
+    ```bash
+    npx emigrate up --no-execution --to 20240118123456789_baseline.sql
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm emigrate up --no-execution --to 20240118123456789_baseline.sql
+    ```
+  </TabItem>
+  <TabItem label="yarn">
+    ```bash
+    yarn emigrate up --no-execution --to 20240118123456789_baseline.sql
+    ```
+  </TabItem>
+  <TabItem label="bun">
+    ```bash
+    bunx --bun emigrate up --no-execution --to 20240118123456789_baseline.sql
+    ```
+  </TabItem>
+  <TabItem label="deno">
+    ```json title="package.json" {3,6}
+    {
+      "scripts": {
+        "emigrate": "emigrate"
+      },
+      "dependencies": {
+        "@emigrate/cli": "*"
+      }
+    }
+    ```
+
+    ```bash
+    deno task emigrate up --no-execution --to 20240118123456789_baseline.sql
+    ```
+  </TabItem>
+</Tabs>
+
+### Verify the baseline migration status
+
+You can verify the status of the baseline migration by running the <Link href="/commands/list/">`emigrate list`</Link> command:
+
+<Tabs>
+  <TabItem label="npm">
+    ```bash
+    npx emigrate list
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm emigrate list
+    ```
+  </TabItem>
+  <TabItem label="yarn">
+    ```bash
+    yarn emigrate list
+    ```
+  </TabItem>
+  <TabItem label="bun">
+    ```bash
+    bunx --bun emigrate list
+    ```
+  </TabItem>
+  <TabItem label="deno">
+    ```json title="package.json" {3,6}
+    {
+      "scripts": {
+        "emigrate": "emigrate"
+      },
+      "dependencies": {
+        "@emigrate/cli": "*"
+      }
+    }
+    ```
+
+    ```bash
+    deno task emigrate list
+    ```
+  </TabItem>
+</Tabs>
+
+Which should output something like this:
+
+```txt title="emigrate list"
+Emigrate list v0.14.1 /your/project/path
+
+  ✔ migrations/20240118123456789_baseline.sql (done)
+
+  1 done (1 total)
+```
+
+### Happy migrating!
+
+You can now start adding new migrations to your migration directory and run <Link href="/commands/up/">`emigrate up`</Link> to apply them to your database.
+Which should be part of your CD pipeline to ensure that your database schema is always up to date in each environment.

--- a/docs/src/content/docs/intro/quick-start.mdx
+++ b/docs/src/content/docs/intro/quick-start.mdx
@@ -95,6 +95,12 @@ Install the plugin you want to use, for example the <Link href="/plugins/storage
 
 ### Create your first migration
 
+<LinkCard
+  href="../../guides/baseline/"
+  title="Baseline your database"
+  description="Learn how to create a baseline of your existing database."
+  />
+
 Create a new migration file in your project using:
 
 <Tabs>
@@ -133,7 +139,7 @@ Create a new migration file in your project using:
   </TabItem>
 </Tabs>
 
-```txt title="Output"
+```txt title="emigrate new"
 Emigrate new v0.10.0 /your/project/path
 
   ✔ migrations/20231215125421364_create_users_table.sql (done) 3ms
@@ -209,7 +215,7 @@ To show both pending and already applied migrations (or previously failed), use 
   </TabItem>
 </Tabs>
 
-```txt title="Example output"
+```txt title="emigrate list"
 Emigrate list v0.10.0 /your/project/path
 
   ✔ migrations/20231211090830577_another_table.sql (done)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,6 +35,10 @@ Options:
   -p, --plugin <name>     The plugin(s) to use (can be specified multiple times)
   -r, --reporter <name>   The reporter to use for reporting the migration progress
   -l, --limit <count>     Limit the number of migrations to run
+  -f, --from <name>       Start running migrations from the given migration name, the given name doesn't need to exist
+                          and is compared in lexicographical order
+  -t, --to <name>         Skip migrations after the given migration name, the given name doesn't need to exist
+                          and is compared in lexicographical order
   --dry                   List the pending migrations that would be run without actually running them
   --color                 Force color output (this option is passed to the reporter)
   --no-color              Disable color output (this option is passed to the reporter)
@@ -45,6 +49,8 @@ Examples:
   emigrate up -d ./migrations --storage @emigrate/mysql
   emigrate up -d src/migrations -s postgres -r json --dry
   emigrate up -d ./migrations -s mysql --import dotenv/config
+  emigrate up --limit 1
+  emigrate up --to 20231122120529381_some_migration_file.js
 ```
 
 ### Examples

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,6 +42,8 @@ Options:
   --dry                   List the pending migrations that would be run without actually running them
   --color                 Force color output (this option is passed to the reporter)
   --no-color              Disable color output (this option is passed to the reporter)
+  --no-execution          Mark the migrations as executed and successful without actually running them,
+                          which is useful if you want to mark migrations as successful after running them manually
 
 Examples:
 
@@ -51,6 +53,7 @@ Examples:
   emigrate up -d ./migrations -s mysql --import dotenv/config
   emigrate up --limit 1
   emigrate up --to 20231122120529381_some_migration_file.js
+  emigrate up --to 20231122120529381_some_migration_file.js --no-execution
 ```
 
 ### Examples

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,6 +20,35 @@ bun add @emigrate/cli
 
 ## Usage
 
+```text
+Usage: emigrate up [options]
+
+Run all pending migrations
+
+Options:
+
+  -h, --help              Show this help message and exit
+  -d, --directory <path>  The directory where the migration files are located (required)
+  -i, --import <module>   Additional modules/packages to import before running the migrations (can be specified multiple times)
+                          For example if you want to use Dotenv to load environment variables or when using TypeScript
+  -s, --storage <name>    The storage to use for where to store the migration history (required)
+  -p, --plugin <name>     The plugin(s) to use (can be specified multiple times)
+  -r, --reporter <name>   The reporter to use for reporting the migration progress
+  -l, --limit <count>     Limit the number of migrations to run
+  --dry                   List the pending migrations that would be run without actually running them
+  --color                 Force color output (this option is passed to the reporter)
+  --no-color              Disable color output (this option is passed to the reporter)
+
+Examples:
+
+  emigrate up --directory src/migrations -s fs
+  emigrate up -d ./migrations --storage @emigrate/mysql
+  emigrate up -d src/migrations -s postgres -r json --dry
+  emigrate up -d ./migrations -s mysql --import dotenv/config
+```
+
+### Examples
+
 Create a new migration:
 
 ```bash

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -52,6 +52,14 @@ const up: Action = async (args) => {
         type: 'string',
         short: 'l',
       },
+      from: {
+        type: 'string',
+        short: 'f',
+      },
+      to: {
+        type: 'string',
+        short: 't',
+      },
       dry: {
         type: 'boolean',
       },
@@ -85,6 +93,10 @@ Options:
   -p, --plugin <name>     The plugin(s) to use (can be specified multiple times)
   -r, --reporter <name>   The reporter to use for reporting the migration progress
   -l, --limit <count>     Limit the number of migrations to run
+  -f, --from <name>       Start running migrations from the given migration name, the given name doesn't need to exist
+                          and is compared in lexicographical order
+  -t, --to <name>         Skip migrations after the given migration name, the given name doesn't need to exist
+                          and is compared in lexicographical order
   --dry                   List the pending migrations that would be run without actually running them
   --color                 Force color output (this option is passed to the reporter)
   --no-color              Disable color output (this option is passed to the reporter)
@@ -95,6 +107,8 @@ Examples:
   emigrate up -d ./migrations --storage @emigrate/mysql
   emigrate up -d src/migrations -s postgres -r json --dry
   emigrate up -d ./migrations -s mysql --import dotenv/config
+  emigrate up --limit 1
+  emigrate up --to 20231122120529381_some_migration_file.js
 `;
 
   if (values.help) {
@@ -109,6 +123,8 @@ Examples:
     storage = config.storage,
     reporter = config.reporter,
     dry,
+    from,
+    to,
     limit: limitString,
     import: imports = [],
   } = values;
@@ -135,6 +151,8 @@ Examples:
       cwd,
       dry,
       limit,
+      from,
+      to,
       color: useColors(values),
     });
   } catch (error) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -72,6 +72,9 @@ const up: Action = async (args) => {
       color: {
         type: 'boolean',
       },
+      'no-execution': {
+        type: 'boolean',
+      },
       'no-color': {
         type: 'boolean',
       },
@@ -100,6 +103,8 @@ Options:
   --dry                   List the pending migrations that would be run without actually running them
   --color                 Force color output (this option is passed to the reporter)
   --no-color              Disable color output (this option is passed to the reporter)
+  --no-execution          Mark the migrations as executed and successful without actually running them,
+                          which is useful if you want to mark migrations as successful after running them manually
 
 Examples:
 
@@ -109,6 +114,7 @@ Examples:
   emigrate up -d ./migrations -s mysql --import dotenv/config
   emigrate up --limit 1
   emigrate up --to 20231122120529381_some_migration_file.js
+  emigrate up --to 20231122120529381_some_migration_file.js --no-execution
 `;
 
   if (values.help) {
@@ -127,6 +133,7 @@ Examples:
     to,
     limit: limitString,
     import: imports = [],
+    'no-execution': noExecution,
   } = values;
   const plugins = [...(config.plugins ?? []), ...(values.plugin ?? [])];
 
@@ -153,6 +160,7 @@ Examples:
       limit,
       from,
       to,
+      noExecution,
       color: useColors(values),
     });
   } catch (error) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -73,16 +73,16 @@ Run all pending migrations
 
 Options:
 
-  -h, --help        Show this help message and exit
-  -d, --directory   The directory where the migration files are located (required)
-  -i, --import      Additional modules/packages to import before running the migrations (can be specified multiple times)
-                    For example if you want to use Dotenv to load environment variables or when using TypeScript
-  -s, --storage     The storage to use for where to store the migration history (required)
-  -p, --plugin      The plugin(s) to use (can be specified multiple times)
-  -r, --reporter    The reporter to use for reporting the migration progress
-  --dry             List the pending migrations that would be run without actually running them
-  --color           Force color output (this option is passed to the reporter)
-  --no-color        Disable color output (this option is passed to the reporter)
+  -h, --help              Show this help message and exit
+  -d, --directory <path>  The directory where the migration files are located (required)
+  -i, --import <module>   Additional modules/packages to import before running the migrations (can be specified multiple times)
+                          For example if you want to use Dotenv to load environment variables or when using TypeScript
+  -s, --storage <name>    The storage to use for where to store the migration history (required)
+  -p, --plugin <name>     The plugin(s) to use (can be specified multiple times)
+  -r, --reporter <name>   The reporter to use for reporting the migration progress
+  --dry                   List the pending migrations that would be run without actually running them
+  --color                 Force color output (this option is passed to the reporter)
+  --no-color              Disable color output (this option is passed to the reporter)
 
 Examples:
 
@@ -176,16 +176,16 @@ Arguments:
 
 Options:
 
-  -h, --help        Show this help message and exit
-  -d, --directory   The directory where the migration files are located (required)
-  -r, --reporter    The reporter to use for reporting the migration file creation progress
-  -p, --plugin      The plugin(s) to use (can be specified multiple times)
-  -t, --template    A template file to use as contents for the new migration file
-                    (if the extension option is not provided the template file's extension will be used)
-  -x, --extension   The extension to use for the new migration file
-                    (if no template or plugin is provided an empty migration file will be created with the given extension)
-  --color           Force color output (this option is passed to the reporter)
-  --no-color        Disable color output (this option is passed to the reporter)
+  -h, --help              Show this help message and exit
+  -d, --directory <path>  The directory where the migration files are located (required)
+  -r, --reporter <name>   The reporter to use for reporting the migration file creation progress
+  -p, --plugin <name>     The plugin(s) to use (can be specified multiple times)
+  -t, --template <path>   A template file to use as contents for the new migration file
+                          (if the extension option is not provided the template file's extension will be used)
+  -x, --extension <ext>   The extension to use for the new migration file
+                          (if no template or plugin is provided an empty migration file will be created with the given extension)
+  --color                 Force color output (this option is passed to the reporter)
+  --no-color              Disable color output (this option is passed to the reporter)
 
   One of the --template, --extension or the --plugin options must be specified
 
@@ -271,14 +271,14 @@ List all migrations and their status. This command does not run any migrations.
 
 Options:
 
-  -h, --help        Show this help message and exit
-  -d, --directory   The directory where the migration files are located (required)
-  -i, --import      Additional modules/packages to import before listing the migrations (can be specified multiple times)
-                    For example if you want to use Dotenv to load environment variables
-  -r, --reporter    The reporter to use for reporting the migrations
-  -s, --storage     The storage to use to get the migration history (required)
-  --color           Force color output (this option is passed to the reporter)
-  --no-color        Disable color output (this option is passed to the reporter)
+  -h, --help              Show this help message and exit
+  -d, --directory <path>  The directory where the migration files are located (required)
+  -i, --import <module>   Additional modules/packages to import before listing the migrations (can be specified multiple times)
+                          For example if you want to use Dotenv to load environment variables
+  -r, --reporter <name>   The reporter to use for reporting the migrations
+  -s, --storage <name>    The storage to use to get the migration history (required)
+  --color                 Force color output (this option is passed to the reporter)
+  --no-color              Disable color output (this option is passed to the reporter)
 
 Examples:
 
@@ -369,16 +369,16 @@ Arguments:
 
 Options:
 
-  -h, --help        Show this help message and exit
-  -d, --directory   The directory where the migration files are located (required)
-  -i, --import      Additional modules/packages to import before removing the migration (can be specified multiple times)
-                    For example if you want to use Dotenv to load environment variables
-  -r, --reporter    The reporter to use for reporting the removal process
-  -s, --storage     The storage to use to get the migration history (required)
-  -f, --force       Force removal of the migration history entry even if the migration file does not exist
-                    or it's in a non-failed state
-  --color           Force color output (this option is passed to the reporter)
-  --no-color        Disable color output (this option is passed to the reporter)
+  -h, --help              Show this help message and exit
+  -d, --directory <path>  The directory where the migration files are located (required)
+  -i, --import <module>   Additional modules/packages to import before removing the migration (can be specified multiple times)
+                          For example if you want to use Dotenv to load environment variables
+  -r, --reporter <name>   The reporter to use for reporting the removal process
+  -s, --storage <name>    The storage to use to get the migration history (required)
+  -f, --force             Force removal of the migration history entry even if the migration file does not exist
+                          or it's in a non-failed state
+  --color                 Force color output (this option is passed to the reporter)
+  --no-color              Disable color output (this option is passed to the reporter)
 
 Examples:
 

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -28,7 +28,7 @@ describe('up', () => {
 
     const exitCode = await run();
 
-    assert.strictEqual(exitCode, 1);
+    assert.strictEqual(exitCode, 1, 'Exit code');
     assertPreconditionsFailed({ dry: false }, reporter, StorageInitError.fromError(new Error('No storage configured')));
   });
 
@@ -37,7 +37,7 @@ describe('up', () => {
 
     const exitCode = await run();
 
-    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(exitCode, 0, 'Exit code');
     assertPreconditionsFulfilled({ dry: false }, reporter, []);
   });
 
@@ -46,7 +46,7 @@ describe('up', () => {
 
     const exitCode = await run();
 
-    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(exitCode, 0, 'Exit code');
     assertPreconditionsFulfilled({ dry: false }, reporter, []);
   });
 
@@ -55,7 +55,7 @@ describe('up', () => {
 
     const exitCode = await run();
 
-    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(exitCode, 0, 'Exit code');
     assertPreconditionsFulfilled({ dry: false }, reporter, []);
   });
 
@@ -78,7 +78,7 @@ describe('up', () => {
 
     const exitCode = await run();
 
-    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(exitCode, 0, 'Exit code');
     assertPreconditionsFulfilled({ dry: false }, reporter, [
       { name: 'some_migration.js', status: 'done', started: true },
       { name: 'some_other_migration.js', status: 'done', started: true },
@@ -106,7 +106,7 @@ describe('up', () => {
 
     const exitCode = await run();
 
-    assert.strictEqual(exitCode, 1);
+    assert.strictEqual(exitCode, 1, 'Exit code');
     assertPreconditionsFulfilled(
       { dry: false },
       reporter,
@@ -125,7 +125,7 @@ describe('up', () => {
 
       const exitCode = await run();
 
-      assert.strictEqual(exitCode, 1);
+      assert.strictEqual(exitCode, 1, 'Exit code');
       assertPreconditionsFulfilled(
         { dry: false },
         reporter,
@@ -146,7 +146,7 @@ describe('up', () => {
 
       const exitCode = await run({ dry: true });
 
-      assert.strictEqual(exitCode, 1);
+      assert.strictEqual(exitCode, 1, 'Exit code');
       assertPreconditionsFulfilled(
         { dry: true },
         reporter,
@@ -170,7 +170,7 @@ describe('up', () => {
 
       const exitCode = await run();
 
-      assert.strictEqual(exitCode, 1);
+      assert.strictEqual(exitCode, 1, 'Exit code');
       assertPreconditionsFulfilled(
         { dry: false },
         reporter,
@@ -198,7 +198,7 @@ describe('up', () => {
 
       const exitCode = await run({ dry: true });
 
-      assert.strictEqual(exitCode, 1);
+      assert.strictEqual(exitCode, 1, 'Exit code');
       assertPreconditionsFulfilled(
         { dry: true },
         reporter,
@@ -226,7 +226,7 @@ describe('up', () => {
 
       const exitCode = await run();
 
-      assert.strictEqual(exitCode, 0);
+      assert.strictEqual(exitCode, 0, 'Exit code');
       assertPreconditionsFulfilled({ dry: false }, reporter, []);
     });
   });
@@ -250,7 +250,7 @@ describe('up', () => {
 
     const exitCode = await run({ limit: 1 });
 
-    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(exitCode, 0, 'Exit code');
     assertPreconditionsFulfilled({ dry: false }, reporter, [
       { name: 'some_migration.js', status: 'done', started: true },
       { name: 'some_other_migration.js', status: 'skipped' },
@@ -267,7 +267,7 @@ describe('up', () => {
 
       const exitCode = await run({ dry: true, limit: 1 });
 
-      assert.strictEqual(exitCode, 0);
+      assert.strictEqual(exitCode, 0, 'Exit code');
       assertPreconditionsFulfilled({ dry: true }, reporter, [
         { name: 'some_migration.js', status: 'pending' },
         { name: 'some_other_migration.js', status: 'skipped' },
@@ -293,7 +293,7 @@ describe('up', () => {
 
       const exitCode = await run({ from: '3_non_existing_migration.js' });
 
-      assert.strictEqual(exitCode, 0);
+      assert.strictEqual(exitCode, 0, 'Exit code');
       assertPreconditionsFulfilled({ dry: false }, reporter, [
         { name: '2_some_migration.js', status: 'skipped' },
         { name: '4_some_other_migration.js', status: 'done', started: true },
@@ -309,7 +309,7 @@ describe('up', () => {
 
       const exitCode = await run({ dry: true, from: '3_non_existing_migration.js' });
 
-      assert.strictEqual(exitCode, 0);
+      assert.strictEqual(exitCode, 0, 'Exit code');
       assertPreconditionsFulfilled({ dry: true }, reporter, [
         { name: '2_some_migration.js', status: 'skipped' },
         { name: '4_some_other_migration.js', status: 'pending' },
@@ -335,7 +335,7 @@ describe('up', () => {
 
       const exitCode = await run({ to: '3_non_existing_migration.js' });
 
-      assert.strictEqual(exitCode, 0);
+      assert.strictEqual(exitCode, 0, 'Exit code');
       assertPreconditionsFulfilled({ dry: false }, reporter, [
         { name: '2_some_migration.js', status: 'done', started: true },
         { name: '4_some_other_migration.js', status: 'skipped' },
@@ -351,7 +351,7 @@ describe('up', () => {
 
       const exitCode = await run({ dry: true, to: '3_non_existing_migration.js' });
 
-      assert.strictEqual(exitCode, 0);
+      assert.strictEqual(exitCode, 0, 'Exit code');
       assertPreconditionsFulfilled({ dry: true }, reporter, [
         { name: '2_some_migration.js', status: 'pending' },
         { name: '4_some_other_migration.js', status: 'skipped' },
@@ -384,7 +384,7 @@ describe('up', () => {
 
       const exitCode = await run({ from: '3_another_migration.js', to: '5_yet_another_migration.js', limit: 2 });
 
-      assert.strictEqual(exitCode, 0);
+      assert.strictEqual(exitCode, 0, 'Exit code');
       assertPreconditionsFulfilled({ dry: false }, reporter, [
         { name: '2_some_migration.js', status: 'skipped' },
         { name: '3_another_migration.js', status: 'done', started: true },
@@ -394,6 +394,92 @@ describe('up', () => {
       ]);
       assert.strictEqual(migration.mock.calls.length, 2);
     });
+  });
+
+  describe('marking migrations as successful without running them', () => {
+    it('returns 0 and finishes without an error when the pending migrations have been marked as successful without executing them', async () => {
+      const migration = mock.fn(async () => {
+        // Success
+      });
+      const { reporter, run } = getUpCommand(
+        [
+          '1_some_already_run_migration.js',
+          '2_some_migration.js',
+          '3_another_migration.js',
+          '4_some_other_migration.js',
+          '5_yet_another_migration.js',
+          '6_some_more_migration.js',
+        ],
+        getStorage(['1_some_already_run_migration.js']),
+        [
+          {
+            loadableExtensions: ['.js'],
+            async loadMigration() {
+              return migration;
+            },
+          },
+        ],
+      );
+
+      const exitCode = await run({
+        from: '3_another_migration.js',
+        to: '5_yet_another_migration.js',
+        limit: 2,
+        noExecution: true,
+      });
+
+      assert.strictEqual(exitCode, 0, 'Exit code');
+      assertPreconditionsFulfilled({ dry: false }, reporter, [
+        { name: '2_some_migration.js', status: 'skipped' },
+        { name: '3_another_migration.js', status: 'done', started: true },
+        { name: '4_some_other_migration.js', status: 'done', started: true },
+        { name: '5_yet_another_migration.js', status: 'skipped' },
+        { name: '6_some_more_migration.js', status: 'skipped' },
+      ]);
+      assert.strictEqual(migration.mock.calls.length, 0);
+    });
+  });
+
+  it('returns 0 and finishes without an error when the pending migrations have been marked as successful without executing them even though they have no corresponding loader', async () => {
+    const migration = mock.fn(async () => {
+      // Success
+    });
+    const { reporter, run } = getUpCommand(
+      [
+        '1_some_already_run_migration.js',
+        '2_some_migration.js',
+        '3_another_migration.js',
+        '4_some_other_migration.sql',
+        '5_yet_another_migration.js',
+        '6_some_more_migration.js',
+      ],
+      getStorage(['1_some_already_run_migration.js']),
+      [
+        {
+          loadableExtensions: ['.js'],
+          async loadMigration() {
+            return migration;
+          },
+        },
+      ],
+    );
+
+    const exitCode = await run({
+      from: '3_another_migration.js',
+      to: '5_yet_another_migration.js',
+      limit: 2,
+      noExecution: true,
+    });
+
+    assert.strictEqual(exitCode, 0, 'Exit code');
+    assertPreconditionsFulfilled({ dry: false }, reporter, [
+      { name: '2_some_migration.js', status: 'skipped' },
+      { name: '3_another_migration.js', status: 'done', started: true },
+      { name: '4_some_other_migration.sql', status: 'done', started: true },
+      { name: '5_yet_another_migration.js', status: 'skipped' },
+      { name: '6_some_more_migration.js', status: 'skipped' },
+    ]);
+    assert.strictEqual(migration.mock.calls.length, 0);
   });
 });
 

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -14,6 +14,7 @@ import { version } from '../get-package-info.js';
 type ExtraFlags = {
   cwd: string;
   dry?: boolean;
+  limit?: number;
   getMigrations?: GetMigrationsFunction;
 };
 
@@ -25,6 +26,7 @@ export default async function upCommand({
   reporter: reporterConfig,
   directory,
   color,
+  limit,
   dry = false,
   plugins = [],
   cwd,
@@ -83,6 +85,7 @@ export default async function upCommand({
 
     const error = await migrationRunner({
       dry,
+      limit,
       reporter,
       storage,
       migrations: await arrayFromAsync(collectedMigrations),

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -17,6 +17,7 @@ type ExtraFlags = {
   limit?: number;
   from?: string;
   to?: string;
+  noExecution?: boolean;
   getMigrations?: GetMigrationsFunction;
 };
 
@@ -31,6 +32,7 @@ export default async function upCommand({
   limit,
   from,
   to,
+  noExecution,
   dry = false,
   plugins = [],
   cwd,
@@ -96,6 +98,10 @@ export default async function upCommand({
       storage,
       migrations: await arrayFromAsync(collectedMigrations),
       async validate(migration) {
+        if (noExecution) {
+          return;
+        }
+
         const loader = getLoaderByExtension(migration.extension);
 
         if (!loader) {
@@ -106,6 +112,10 @@ export default async function upCommand({
         }
       },
       async execute(migration) {
+        if (noExecution) {
+          return;
+        }
+
         const loader = getLoaderByExtension(migration.extension)!;
         const [migrationFunction, loadError] = await exec(async () => loader.loadMigration(migration));
 

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -15,6 +15,8 @@ type ExtraFlags = {
   cwd: string;
   dry?: boolean;
   limit?: number;
+  from?: string;
+  to?: string;
   getMigrations?: GetMigrationsFunction;
 };
 
@@ -27,6 +29,8 @@ export default async function upCommand({
   directory,
   color,
   limit,
+  from,
+  to,
   dry = false,
   plugins = [],
   cwd,
@@ -86,6 +90,8 @@ export default async function upCommand({
     const error = await migrationRunner({
       dry,
       limit,
+      from,
+      to,
       reporter,
       storage,
       migrations: await arrayFromAsync(collectedMigrations),


### PR DESCRIPTION
* `-l, --limit <count>` - used to limit the number of migrations to run
* `-f, --from <name>` - used to set which migration to start from when running migrations
* `-t, --to <name>` - used to set which migration to end at when running migrations
* `--no-execution` - used to log migrations as successful without actually executing them