### PR TITLE
feat(cli): handle process abortion gracefully

### DIFF
--- a/.changeset/bright-poems-fold.md
+++ b/.changeset/bright-poems-fold.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/docs': minor
+---
+
+Document the --abort-respite CLI option and the corresponding abortRespite config

--- a/.changeset/late-phones-smile.md
+++ b/.changeset/late-phones-smile.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/types': minor
+---
+
+Add type for onAbort Reporter method

--- a/.changeset/pink-hairs-kiss.md
+++ b/.changeset/pink-hairs-kiss.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/reporter-pino': minor
+---
+
+Handle the new onAbort method

--- a/.changeset/wicked-turkeys-smile.md
+++ b/.changeset/wicked-turkeys-smile.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': minor
+---
+
+Handle process interruptions gracefully, e.g. due to receiving a SIGINT or SIGTERM signal. If a migration is currently running when the process is about to shutdown it will have a maximum of 10 more seconds to finish before being deserted (there's no way to cancel a promise sadly, and many database queries are not easy to abort either). The 10 second respite length can be customized using the --abort-respite CLI option or the abortRespite config.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Options:
   --no-color              Disable color output (this option is passed to the reporter)
   --no-execution          Mark the migrations as executed and successful without actually running them,
                           which is useful if you want to mark migrations as successful after running them manually
+  --abort-respite <sec>   The number of seconds to wait before abandoning running migrations after the command has been aborted (default: 10)
 
 Examples:
 

--- a/docs/src/content/docs/commands/up.mdx
+++ b/docs/src/content/docs/commands/up.mdx
@@ -66,6 +66,8 @@ List the pending migrations that would be run without actually running them
 
 ### `-l, --limit <count>`
 
+**type:** `number`
+
 Limit the number of migrations to run. Can be combined with `--dry` which will show "pending" for the migrations that would be run if not in dry-run mode,
 and "skipped" for the migrations that also haven't been run but won't because of the set limit.
 
@@ -155,3 +157,10 @@ which is useful if you want to mark migrations as successful after running them 
 :::tip
 See the <Link href="/guides/baseline/">Baseline guide</Link> for example usage of the `--no-execution` option
 :::
+
+### `--abort-respite`
+
+**type:** `number`  
+**default:** `10`
+
+Customize the number of seconds to wait before abandoning a running migration when the process is about to shutdown, for instance when the user presses `Ctrl+C` or when the container is being stopped (if running inside a container).

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -157,3 +157,16 @@ export default {
 ```
 
 Will create new migration files with the `.ts` extension.
+
+### `abortRespite`
+
+**type:** `number`  
+**default:** `10`
+
+Customize the number of seconds to wait before abandoning a running migration when the process is about to shutdown, for instance when the user presses `Ctrl+C` or when the container is being stopped (if running inside a container).
+
+```js title="emigrate.config.js" {2}
+export default {
+  abortRespite: 10,
+};
+```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -44,6 +44,7 @@ Options:
   --no-color              Disable color output (this option is passed to the reporter)
   --no-execution          Mark the migrations as executed and successful without actually running them,
                           which is useful if you want to mark migrations as successful after running them manually
+  --abort-respite <sec>   The number of seconds to wait before abandoning running migrations after the command has been aborted (default: 10)
 
 Examples:
 

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -19,6 +19,8 @@ type ExtraFlags = {
   to?: string;
   noExecution?: boolean;
   getMigrations?: GetMigrationsFunction;
+  abortSignal?: AbortSignal;
+  abortRespite?: number;
 };
 
 const lazyDefaultReporter = async () => import('../reporters/default.js');
@@ -33,6 +35,8 @@ export default async function upCommand({
   from,
   to,
   noExecution,
+  abortSignal,
+  abortRespite,
   dry = false,
   plugins = [],
   cwd,
@@ -94,6 +98,8 @@ export default async function upCommand({
       limit,
       from,
       to,
+      abortSignal,
+      abortRespite,
       reporter,
       storage,
       migrations: await arrayFromAsync(collectedMigrations),

--- a/packages/cli/src/defaults.ts
+++ b/packages/cli/src/defaults.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const DEFAULT_RESPITE_SECONDS = 10;

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -146,6 +146,30 @@ export class StorageInitError extends EmigrateError {
   }
 }
 
+export class CommandAbortError extends EmigrateError {
+  static fromSignal(signal: NodeJS.Signals) {
+    return new CommandAbortError(`Command aborted due to signal: ${signal}`);
+  }
+
+  static fromReason(reason: string, cause?: unknown) {
+    return new CommandAbortError(`Command aborted: ${reason}`, { cause });
+  }
+
+  constructor(message: string | undefined, options?: ErrorOptions) {
+    super(message, options, 'ERR_COMMAND_ABORT');
+  }
+}
+
+export class ExecutionDesertedError extends EmigrateError {
+  static fromReason(reason: string, cause?: Error) {
+    return new ExecutionDesertedError(`Execution deserted: ${reason}`, { cause });
+  }
+
+  constructor(message: string | undefined, options?: ErrorOptions) {
+    super(message, options, 'ERR_EXECUTION_DESERTED');
+  }
+}
+
 errorConstructors.set('EmigrateError', EmigrateError as ErrorConstructor);
 errorConstructors.set('ShowUsageError', ShowUsageError as ErrorConstructor);
 errorConstructors.set('MissingOptionError', MissingOptionError as unknown as ErrorConstructor);
@@ -158,3 +182,5 @@ errorConstructors.set('MigrationLoadError', MigrationLoadError as unknown as Err
 errorConstructors.set('MigrationRunError', MigrationRunError as unknown as ErrorConstructor);
 errorConstructors.set('MigrationNotRunError', MigrationNotRunError as unknown as ErrorConstructor);
 errorConstructors.set('StorageInitError', StorageInitError as unknown as ErrorConstructor);
+errorConstructors.set('CommandAbortError', CommandAbortError as unknown as ErrorConstructor);
+errorConstructors.set('ExecutionDesertedError', ExecutionDesertedError as unknown as ErrorConstructor);

--- a/packages/cli/src/exec.ts
+++ b/packages/cli/src/exec.ts
@@ -1,22 +1,65 @@
-import { toError } from './errors.js';
+import prettyMs from 'pretty-ms';
+import { ExecutionDesertedError, toError } from './errors.js';
+import { DEFAULT_RESPITE_SECONDS } from './defaults.js';
 
-type Fn<Args extends any[], Result> = (...args: Args) => Result;
 type Result<T> = [value: T, error: undefined] | [value: undefined, error: Error];
+
+type ExecOptions = {
+  abortSignal?: AbortSignal;
+  abortRespite?: number;
+};
 
 /**
  * Execute a function and return a result tuple
  *
  * This is a helper function to make it easier to handle errors without the extra nesting of try/catch
+ * If an abort signal is provided the function will reject with an ExecutionDesertedError if the signal is aborted
+ * and the given function has not yet resolved within the given respite time (or a default of 30 seconds)
+ *
+ * @param fn The function to execute
+ * @param options Options for the execution
  */
-export const exec = async <Args extends any[], Return extends Promise<any>>(
-  fn: Fn<Args, Return>,
-  ...args: Args
+export const exec = async <Return extends Promise<any>>(
+  fn: () => Return,
+  options: ExecOptions = {},
 ): Promise<Result<Awaited<Return>>> => {
   try {
-    const result = await fn(...args);
+    const aborter = options.abortSignal ? getAborter(options.abortSignal, options.abortRespite) : undefined;
+    const result = await Promise.race(aborter ? [aborter, fn()] : [fn()]);
 
     return [result, undefined];
   } catch (error) {
     return [undefined, toError(error)];
   }
+};
+
+/**
+ * Returns a promise that rejects after a given time after the given signal is aborted
+ *
+ * @param signal The abort signal to listen to
+ * @param respite The time in milliseconds to wait before rejecting
+ */
+const getAborter = async (signal: AbortSignal, respite = DEFAULT_RESPITE_SECONDS * 1000): Promise<never> => {
+  return new Promise((_, reject) => {
+    if (signal.aborted) {
+      setTimeout(
+        reject,
+        respite,
+        ExecutionDesertedError.fromReason(`Deserted after ${prettyMs(respite)}`, toError(signal.reason)),
+      ).unref();
+      return;
+    }
+
+    signal.addEventListener(
+      'abort',
+      () => {
+        setTimeout(
+          reject,
+          respite,
+          ExecutionDesertedError.fromReason(`Deserted after ${prettyMs(respite)}`, toError(signal.reason)),
+        ).unref();
+      },
+      { once: true },
+    );
+  });
 };

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -12,6 +12,7 @@ export type Config = {
   template?: string;
   extension?: string;
   color?: boolean;
+  abortRespite?: number;
 };
 
 export type EmigrateConfig = Config & {

--- a/packages/reporter-pino/src/index.ts
+++ b/packages/reporter-pino/src/index.ts
@@ -57,6 +57,10 @@ class PinoReporter implements Required<EmigrateReporter> {
     this.#logger.info({ parameters }, `Emigrate "${command}" initialized${parameters.dry ? ' (dry-run)' : ''}`);
   }
 
+  onAbort(reason: Error): Awaitable<void> {
+    this.#logger.error({ reason }, `Emigrate "${this.#command}" shutting down`);
+  }
+
   onCollectedMigrations(migrations: MigrationMetadata[]): Awaitable<void> {
     this.#migrations = migrations;
   }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -244,6 +244,14 @@ export type EmigrateReporter = Partial<{
    */
   onInit(parameters: ReporterInitParameters): Awaitable<void>;
   /**
+   * Called when the current command (in practice the "up" command) is aborted.
+   *
+   * This is called when the process is interrupted, e.g. by a SIGTERM or SIGINT signal, or an unhandled error occurs.
+   *
+   * @param reason The reason why the command was aborted.
+   */
+  onAbort(reason: Error): Awaitable<void>;
+  /**
    * Called when all pending migrations that should be executed have been collected.
    *
    * @param migrations The pending migrations that will be executed.


### PR DESCRIPTION
When the process is aborted, either due to receiving a SIGINT or SIGTERM signal or because of an unhandled exception or rejected promise, the migration process will shutdown gracefully.
This means that the locked migrations will be unlocked, and any resources in the storage plugins will be cleaned up.

But in case there's a currently running migration during the process abortion (it usually is) it will have 10 more seconds (customisable using the `--abort-respite` CLI option or the `abortRespite` config) to finish before being abandoned. It's abandoned because promises can't be cancelled at the moment. If the migration finishes within the "abort respite" period it will be marked as successful, and if it doesn't finish within the respite window it will be marked as failed. All the following migrations will be skipped either way.