### PR TITLE
feat(remove): rework the "remove" command to be more similar to "up" and "list"

### DIFF
--- a/.changeset/eleven-files-love.md
+++ b/.changeset/eleven-files-love.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/types': minor
+---
+
+Remove the "remove" command specific reporter methods. So instead of using `onMigrationRemoveStart`, `onMigrationRemoveSuccess` and `onMigrationRemoveError` the `onMigrationStart`, `onMigrationSuccess` and `onMigrationError` methods should be used and the reporter can still format the output differently depending on the current command (which it receives in the `onInit` method). This is a BREAKING CHANGE.

--- a/.changeset/odd-foxes-mix.md
+++ b/.changeset/odd-foxes-mix.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': minor
+---
+
+Add support for passing the relative path to a migration file to remove from the history using the "remove" command

--- a/.changeset/purple-eagles-speak.md
+++ b/.changeset/purple-eagles-speak.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': patch
+---
+
+Don't dim decimal points in durations in the default reporter

--- a/.changeset/sharp-cows-joke.md
+++ b/.changeset/sharp-cows-joke.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': patch
+---
+
+Set Emigrate error instance names from their respective constructor's name for consistency and correct error deserialization.

--- a/.changeset/tame-apples-lick.md
+++ b/.changeset/tame-apples-lick.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/reporter-pino': minor
+---
+
+Adapt to the new Reporter interface, i.e. the removal of the "remove" command related methods

--- a/.changeset/thin-pillows-obey.md
+++ b/.changeset/thin-pillows-obey.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': minor
+---
+
+Completely rework how the "remove" command is run, this is to make it more similar to the "up" and "list" command as now it will also use the `onMigrationStart`, `onMigrationSuccess` and `onMigrationError` reporter methods when reporting the command progress. It's also in preparation for adding `--from` and `--to` CLI options for the "remove" command, similar to how the same options work for the "up" command.

--- a/docs/src/content/docs/commands/remove.mdx
+++ b/docs/src/content/docs/commands/remove.mdx
@@ -13,22 +13,22 @@ The `remove` command is used to remove a migration from the history. This is use
 <Tabs>
   <TabItem label="npm">
     ```bash
-    npx emigrate remove [options] <name>
+    npx emigrate remove [options] <name/path>
     ```
   </TabItem>
   <TabItem label="pnpm">
     ```bash
-    pnpm emigrate remove [options] <name>
+    pnpm emigrate remove [options] <name/path>
     ```
   </TabItem>
   <TabItem label="yarn">
     ```bash
-    yarn emigrate remove [options] <name>
+    yarn emigrate remove [options] <name/path>
     ```
   </TabItem>
   <TabItem label="bun">
     ```bash
-    bunx --bun emigrate remove [options] <name>
+    bunx --bun emigrate remove [options] <name/path>
     ```
   </TabItem>
   <TabItem label="deno">
@@ -44,16 +44,18 @@ The `remove` command is used to remove a migration from the history. This is use
     ```
 
     ```bash
-    deno task emigrate remove [options] <name>
+    deno task emigrate remove [options] <name/path>
     ```
   </TabItem>
 </Tabs>
 
 ## Arguments
 
-### `<name>`
+### `<name/path>`
 
-The name of the migration file to remove, including the extension, e.g. `20200101000000_some_migration.js`.
+The name of the migration file to remove, including the extension, e.g. `20200101000000_some_migration.js`, or a relative file path to a migration file to remove, e.g: `migrations/20200101000000_some_migration.js`.
+
+Using relative file paths is useful in terminals that support autocomplete, and also when you copy and use the relative migration file path from the output of the <Link href="/commands/list/">`list`</Link> command.
 
 ## Options
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
       {
         "files": "packages/**/*.test.ts",
         "rules": {
-          "@typescript-eslint/no-floating-promises": 0
+          "@typescript-eslint/no-floating-promises": 0,
+          "max-params": 0
         }
       }
     ]

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,6 +21,24 @@ bun add @emigrate/cli
 ## Usage
 
 ```text
+Usage: emigrate <options>/<command>
+
+Options:
+
+  -h, --help     Show this help message and exit
+  -v, --version  Print version number and exit
+
+Commands:
+
+  up      Run all pending migrations (or do a dry run)
+  new     Create a new migration file
+  list    List all migrations and their status
+  remove  Remove entries from the migration history
+```
+
+### `emigrate up`
+
+```text
 Usage: emigrate up [options]
 
 Run all pending migrations

--- a/packages/cli/src/array-map-async.ts
+++ b/packages/cli/src/array-map-async.ts
@@ -1,0 +1,5 @@
+export async function* arrayMapAsync<T, U>(iterable: AsyncIterable<T>, mapper: (item: T) => U): AsyncIterable<U> {
+  for await (const item of iterable) {
+    yield mapper(item);
+  }
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -440,14 +440,14 @@ const remove: Action = async (args) => {
     allowPositionals: true,
   });
 
-  const usage = `Usage: emigrate remove [options] <name>
+  const usage = `Usage: emigrate remove [options] <name/path>
 
 Remove entries from the migration history.
 This is useful if you want to retry a migration that has failed.
 
 Arguments:
 
-  name   The name of the migration file to remove from the history (required)
+  name/path               The name of or relative path to the migration file to remove from the history (required)
 
 Options:
 
@@ -466,6 +466,7 @@ Examples:
   emigrate remove -d migrations -s fs 20231122120529381_some_migration_file.js
   emigrate remove --directory ./migrations --storage postgres 20231122120529381_some_migration_file.sql
   emigrate remove -i dotenv/config -d ./migrations -s postgres 20231122120529381_some_migration_file.sql
+  emigrate remove -i dotenv/config -d ./migrations -s postgres migrations/20231122120529381_some_migration_file.sql
 `;
 
   if (values.help) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -457,8 +457,7 @@ Options:
                           For example if you want to use Dotenv to load environment variables
   -r, --reporter <name>   The reporter to use for reporting the removal process
   -s, --storage <name>    The storage to use to get the migration history (required)
-  -f, --force             Force removal of the migration history entry even if the migration file does not exist
-                          or it's in a non-failed state
+  -f, --force             Force removal of the migration history entry even if the migration is not in a failed state
   --color                 Force color output (this option is passed to the reporter)
   --no-color              Disable color output (this option is passed to the reporter)
 

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -62,6 +62,12 @@ export default async function listCommand({
       async execute() {
         throw new Error('Unexpected execute call');
       },
+      async onSuccess() {
+        throw new Error('Unexpected onSuccess call');
+      },
+      async onError() {
+        throw new Error('Unexpected onError call');
+      },
     });
 
     return error ? 1 : 0;

--- a/packages/cli/src/commands/remove.test.ts
+++ b/packages/cli/src/commands/remove.test.ts
@@ -1,0 +1,306 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { type EmigrateReporter, type Storage, type Plugin, type MigrationMetadataFinished } from '@emigrate/types';
+import { deserializeError } from 'serialize-error';
+import { version } from '../get-package-info.js';
+import {
+  BadOptionError,
+  MigrationNotRunError,
+  MigrationRemovalError,
+  OptionNeededError,
+  StorageInitError,
+} from '../errors.js';
+import {
+  getErrorCause,
+  getMockedReporter,
+  getMockedStorage,
+  toEntry,
+  toMigrations,
+  type Mocked,
+} from '../test-utils.js';
+import removeCommand from './remove.js';
+
+describe('remove', () => {
+  it("returns 1 and finishes with an error when the storage couldn't be initialized", async () => {
+    const { reporter, run } = getRemoveCommand([]);
+
+    const exitCode = await run('some_migration.js');
+
+    assert.strictEqual(exitCode, 1, 'Exit code');
+    assertPreconditionsFailed(reporter, StorageInitError.fromError(new Error('No storage configured')));
+  });
+
+  it('returns 1 and finishes with an error when the given migration has not been executed', async () => {
+    const storage = getMockedStorage(['some_other_migration.js']);
+    const { reporter, run } = getRemoveCommand(['some_migration.js'], storage);
+
+    const exitCode = await run('some_migration.js');
+
+    assert.strictEqual(exitCode, 1, 'Exit code');
+    assertPreconditionsFulfilled(
+      reporter,
+      storage,
+      [
+        {
+          name: 'some_migration.js',
+          status: 'failed',
+          error: new MigrationNotRunError('Migration "some_migration.js" is not in the migration history'),
+        },
+      ],
+      new MigrationNotRunError('Migration "some_migration.js" is not in the migration history'),
+    );
+  });
+
+  it('returns 1 and finishes with an error when the given migration is not in a failed state in the history', async () => {
+    const storage = getMockedStorage(['1_old_migration.js', '2_some_migration.js', '3_new_migration.js']);
+    const { reporter, run } = getRemoveCommand(['2_some_migration.js'], storage);
+
+    const exitCode = await run('2_some_migration.js');
+
+    assert.strictEqual(exitCode, 1, 'Exit code');
+    assertPreconditionsFulfilled(
+      reporter,
+      storage,
+      [
+        {
+          name: '2_some_migration.js',
+          status: 'failed',
+          error: OptionNeededError.fromOption(
+            'force',
+            'The migration "2_some_migration.js" is not in a failed state. Use the "force" option to force its removal',
+          ),
+        },
+      ],
+      OptionNeededError.fromOption(
+        'force',
+        'The migration "2_some_migration.js" is not in a failed state. Use the "force" option to force its removal',
+      ),
+    );
+  });
+
+  it('returns 1 and finishes with an error when the given migration does not exist at all', async () => {
+    const storage = getMockedStorage(['some_migration.js']);
+    const { reporter, run } = getRemoveCommand(['some_migration.js'], storage);
+
+    const exitCode = await run('some_other_migration.js');
+
+    assert.strictEqual(exitCode, 1, 'Exit code');
+    assertPreconditionsFulfilled(
+      reporter,
+      storage,
+      [],
+      BadOptionError.fromOption('name', 'The migration: "migrations/some_other_migration.js" was not found'),
+    );
+  });
+
+  it('returns 0, removes the migration from the history and finishes without an error when the given migration is in a failed state', async () => {
+    const storage = getMockedStorage([toEntry('some_migration.js', 'failed')]);
+    const { reporter, run } = getRemoveCommand(['some_migration.js'], storage);
+
+    const exitCode = await run('some_migration.js');
+
+    assert.strictEqual(exitCode, 0, 'Exit code');
+    assertPreconditionsFulfilled(reporter, storage, [{ name: 'some_migration.js', status: 'done', started: true }]);
+  });
+
+  it('returns 0, removes the migration from the history and finishes without an error when the given migration is not in a failed state but "force" is true', async () => {
+    const storage = getMockedStorage(['1_old_migration.js', '2_some_migration.js', '3_new_migration.js']);
+    const { reporter, run } = getRemoveCommand(['2_some_migration.js'], storage);
+
+    const exitCode = await run('2_some_migration.js', { force: true });
+
+    assert.strictEqual(exitCode, 0, 'Exit code');
+    assertPreconditionsFulfilled(reporter, storage, [{ name: '2_some_migration.js', status: 'done', started: true }]);
+  });
+
+  it('returns 1 and finishes with an error when the removal of the migration crashes', async () => {
+    const storage = getMockedStorage([toEntry('some_migration.js', 'failed')]);
+    storage.remove.mock.mockImplementation(async () => {
+      throw new Error('Some error');
+    });
+    const { reporter, run } = getRemoveCommand(['some_migration.js'], storage);
+
+    const exitCode = await run('some_migration.js');
+
+    assert.strictEqual(exitCode, 1, 'Exit code');
+    assertPreconditionsFulfilled(
+      reporter,
+      storage,
+      [
+        {
+          name: 'some_migration.js',
+          status: 'failed',
+          error: new Error('Some error'),
+          started: true,
+        },
+      ],
+      new MigrationRemovalError('Failed to remove migration: migrations/some_migration.js', {
+        cause: new Error('Some error'),
+      }),
+    );
+  });
+});
+
+function getRemoveCommand(migrationFiles: string[], storage?: Mocked<Storage>, plugins?: Plugin[]) {
+  const reporter = getMockedReporter();
+
+  const run = async (
+    name: string,
+    options?: Omit<Parameters<typeof removeCommand>[0], 'cwd' | 'directory' | 'storage' | 'reporter' | 'plugins'>,
+  ) => {
+    return removeCommand(
+      {
+        cwd: '/emigrate',
+        directory: 'migrations',
+        storage: {
+          async initializeStorage() {
+            if (!storage) {
+              throw new Error('No storage configured');
+            }
+
+            return storage;
+          },
+        },
+        reporter,
+        plugins: plugins ?? [],
+        async getMigrations(cwd, directory) {
+          return toMigrations(cwd, directory, migrationFiles);
+        },
+        ...options,
+      },
+      name,
+    );
+  };
+
+  return {
+    reporter,
+    storage,
+    run,
+  };
+}
+
+function assertPreconditionsFailed(reporter: Mocked<Required<EmigrateReporter>>, finishedError?: Error) {
+  assert.strictEqual(reporter.onInit.mock.calls.length, 1);
+  assert.deepStrictEqual(reporter.onInit.mock.calls[0]?.arguments, [
+    {
+      command: 'remove',
+      cwd: '/emigrate',
+      version,
+      dry: false,
+      color: undefined,
+      directory: 'migrations',
+    },
+  ]);
+  assert.strictEqual(reporter.onCollectedMigrations.mock.calls.length, 0, 'Collected call');
+  assert.strictEqual(reporter.onLockedMigrations.mock.calls.length, 0, 'Locked call');
+  assert.strictEqual(reporter.onMigrationStart.mock.calls.length, 0, 'Started migrations');
+  assert.strictEqual(reporter.onMigrationSuccess.mock.calls.length, 0, 'Successful migrations');
+  assert.strictEqual(reporter.onMigrationError.mock.calls.length, 0, 'Failed migrations');
+  assert.strictEqual(reporter.onMigrationSkip.mock.calls.length, 0, 'Total pending and skipped');
+  assert.strictEqual(reporter.onFinished.mock.calls.length, 1, 'Finished called once');
+  const [entries, error] = reporter.onFinished.mock.calls[0]?.arguments ?? [];
+  assert.deepStrictEqual(error, finishedError, 'Finished error');
+  const cause = getErrorCause(error);
+  const expectedCause = finishedError?.cause;
+  assert.deepStrictEqual(
+    cause,
+    expectedCause ? deserializeError(expectedCause) : expectedCause,
+    'Finished error cause',
+  );
+  assert.strictEqual(entries?.length, 0, 'Finished entries length');
+}
+
+function assertPreconditionsFulfilled(
+  reporter: Mocked<Required<EmigrateReporter>>,
+  storage: Mocked<Storage>,
+  expected: Array<{ name: string; status: MigrationMetadataFinished['status']; started?: boolean; error?: Error }>,
+  finishedError?: Error,
+) {
+  assert.strictEqual(reporter.onInit.mock.calls.length, 1);
+  assert.deepStrictEqual(reporter.onInit.mock.calls[0]?.arguments, [
+    {
+      command: 'remove',
+      cwd: '/emigrate',
+      version,
+      dry: false,
+      color: undefined,
+      directory: 'migrations',
+    },
+  ]);
+
+  let started = 0;
+  let done = 0;
+  let failed = 0;
+  let skipped = 0;
+  let pending = 0;
+  let failedAndStarted = 0;
+  const failedEntries: typeof expected = [];
+  const successfulEntries: typeof expected = [];
+
+  for (const entry of expected) {
+    if (entry.started) {
+      started++;
+    }
+
+    // eslint-disable-next-line default-case
+    switch (entry.status) {
+      case 'done': {
+        done++;
+
+        if (entry.started) {
+          successfulEntries.push(entry);
+        }
+
+        break;
+      }
+
+      case 'failed': {
+        failed++;
+        failedEntries.push(entry);
+
+        if (entry.started) {
+          failedAndStarted++;
+        }
+
+        break;
+      }
+
+      case 'skipped': {
+        skipped++;
+        break;
+      }
+
+      case 'pending': {
+        pending++;
+        break;
+      }
+    }
+  }
+
+  assert.strictEqual(reporter.onCollectedMigrations.mock.calls.length, 1, 'Collected call');
+  assert.strictEqual(storage.lock.mock.calls.length, 0, 'Storage lock never called');
+  assert.strictEqual(storage.unlock.mock.calls.length, 0, 'Storage unlock never called');
+  assert.strictEqual(reporter.onLockedMigrations.mock.calls.length, 0, 'Locked call');
+  assert.strictEqual(reporter.onMigrationStart.mock.calls.length, started, 'Started migrations');
+  assert.strictEqual(reporter.onMigrationSuccess.mock.calls.length, successfulEntries.length, 'Successful migrations');
+  assert.strictEqual(storage.remove.mock.calls.length, started, 'Storage remove called');
+  assert.strictEqual(reporter.onMigrationError.mock.calls.length, failedEntries.length, 'Failed migrations');
+  assert.strictEqual(reporter.onMigrationSkip.mock.calls.length, 0, 'Total pending and skipped');
+  assert.strictEqual(reporter.onFinished.mock.calls.length, 1, 'Finished called once');
+  const [entries, error] = reporter.onFinished.mock.calls[0]?.arguments ?? [];
+  assert.deepStrictEqual(error, finishedError, 'Finished error');
+  const cause = getErrorCause(error);
+  const expectedCause = finishedError?.cause;
+  assert.deepStrictEqual(
+    cause,
+    expectedCause ? deserializeError(expectedCause) : expectedCause,
+    'Finished error cause',
+  );
+  assert.strictEqual(entries?.length, expected.length, 'Finished entries length');
+  assert.deepStrictEqual(
+    entries.map((entry) => `${entry.name} (${entry.status})`),
+    expected.map((entry) => `${entry.name} (${entry.status})`),
+    'Finished entries',
+  );
+  assert.strictEqual(storage.end.mock.calls.length, 1, 'Storage end called once');
+}

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -1,7 +1,14 @@
 import path from 'node:path';
 import { getOrLoadPlugins, getOrLoadReporter, getOrLoadStorage } from '@emigrate/plugin-tools';
 import { isFinishedMigration, type LoaderPlugin } from '@emigrate/types';
-import { BadOptionError, MigrationLoadError, MissingOptionError, StorageInitError, toError } from '../errors.js';
+import {
+  BadOptionError,
+  MigrationLoadError,
+  MissingOptionError,
+  StorageInitError,
+  toError,
+  toSerializedError,
+} from '../errors.js';
 import { type Config } from '../types.js';
 import { withLeadingPeriod } from '../with-leading-period.js';
 import { type GetMigrationsFunction } from '../get-migrations.js';
@@ -137,6 +144,12 @@ export default async function upCommand({
         }
 
         await migrationFunction();
+      },
+      async onSuccess(migration) {
+        await storage.onSuccess(migration);
+      },
+      async onError(migration, error) {
+        await storage.onError(migration, toSerializedError(error));
       },
     });
 

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -23,6 +23,7 @@ export class EmigrateError extends Error {
     public code?: string,
   ) {
     super(message, options);
+    this.name = this.constructor.name;
   }
 }
 

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -137,6 +137,16 @@ export class MigrationNotRunError extends EmigrateError {
   }
 }
 
+export class MigrationRemovalError extends EmigrateError {
+  static fromMetadata(metadata: MigrationMetadata, cause?: Error) {
+    return new MigrationRemovalError(`Failed to remove migration: ${metadata.relativeFilePath}`, { cause });
+  }
+
+  constructor(message: string | undefined, options?: ErrorOptions) {
+    super(message, options, 'ERR_MIGRATION_REMOVE');
+  }
+}
+
 export class StorageInitError extends EmigrateError {
   static fromError(error: Error) {
     return new StorageInitError('Could not initialize storage', { cause: error });
@@ -182,6 +192,7 @@ errorConstructors.set('MigrationHistoryError', MigrationHistoryError as unknown 
 errorConstructors.set('MigrationLoadError', MigrationLoadError as unknown as ErrorConstructor);
 errorConstructors.set('MigrationRunError', MigrationRunError as unknown as ErrorConstructor);
 errorConstructors.set('MigrationNotRunError', MigrationNotRunError as unknown as ErrorConstructor);
+errorConstructors.set('MigrationRemovalError', MigrationRemovalError as unknown as ErrorConstructor);
 errorConstructors.set('StorageInitError', StorageInitError as unknown as ErrorConstructor);
 errorConstructors.set('CommandAbortError', CommandAbortError as unknown as ErrorConstructor);
 errorConstructors.set('ExecutionDesertedError', ExecutionDesertedError as unknown as ErrorConstructor);

--- a/packages/cli/src/reporters/default.ts
+++ b/packages/cli/src/reporters/default.ts
@@ -21,7 +21,7 @@ const spinner = interactive ? elegantSpinner() : () => figures.pointerSmall;
 const formatDuration = (duration: number): string => {
   const pretty = prettyMs(duration);
 
-  return yellow(pretty.replaceAll(/([^\s\d]+)/g, dim('$1')));
+  return yellow(pretty.replaceAll(/([^\s\d.]+)/g, dim('$1')));
 };
 
 const getTitle = ({ command, version, dry, cwd }: ReporterInitParameters) => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -273,35 +273,19 @@ export type EmigrateReporter = Partial<{
    */
   onNewMigration(migration: MigrationMetadata, content: string): Awaitable<void>;
   /**
-   * Called when a migration is about to be removed from the migration history.
-   *
-   * This is only called when the command is 'remove'.
-   */
-  onMigrationRemoveStart(migration: MigrationMetadata): Awaitable<void>;
-  /**
-   * Called when a migration is successfully removed from the migration history.
-   *
-   * This is only called when the command is 'remove'.
-   */
-  onMigrationRemoveSuccess(migration: SuccessfulMigrationMetadata): Awaitable<void>;
-  /**
-   * Called when a migration couldn't be removed from the migration history.
-   *
-   * This is only called when the command is 'remove'.
-   */
-  onMigrationRemoveError(migration: FailedMigrationMetadata, error: Error): Awaitable<void>;
-  /**
    * Called when a migration is about to be executed.
    *
-   * Will only be called for each migration when the command is "up".
+   * Will be called for each migration when the command is "up",
+   * or before removing each migration from the history when the command is "remove".
    *
-   * @param migration Information about the migration that is about to be executed.
+   * @param migration Information about the migration that is about to be executed/removed.
    */
   onMigrationStart(migration: MigrationMetadata): Awaitable<void>;
   /**
    * Called when a migration has been successfully executed.
    *
-   * Will be called after a successful migration when the command is "up"
+   * Will be called after a successful migration when the command is "up",
+   * or after a successful removal of a migration from the history when the command is "remove",
    * or for each successful migration from the history when the command is "list".
    *
    * @param migration Information about the migration that was executed.
@@ -310,7 +294,8 @@ export type EmigrateReporter = Partial<{
   /**
    * Called when a migration has failed.
    *
-   * Will be called after a failed migration when the command is "up"
+   * Will be called after a failed migration when the command is "up",
+   * or after a failed removal of a migration from the history when the command is "remove",
    * or for each failed migration from the history when the command is "list" (will be at most one in this case).
    *
    * @param migration Information about the migration that failed.


### PR DESCRIPTION
The `EmigrateReporter` interface has been simplified by removing the "remove" command specific methods, the "remove" command now uses `onMigrationStart`, `onMigrationSuccess` and `onMigrationError` as the other commands.

The "remove" command can now also take a relative path to a migration file as the argument, which is useful in terminals with autocomplete support or when copying and using the output from for instance the "list" command as the argument to "remove".