### PR TITLE
fix(storage): make sure the storage initialization crashes when db connection can't be established

### DIFF
--- a/.changeset/tasty-bulldogs-guess.md
+++ b/.changeset/tasty-bulldogs-guess.md
@@ -1,0 +1,6 @@
+---
+'@emigrate/postgres': patch
+'@emigrate/mysql': patch
+---
+
+Make sure the storage initialization crashes when a database connection can't be established

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -171,6 +171,8 @@ export const createMysqlStorage = ({ table = defaultTable, connection }: MysqlSt
     async initializeStorage() {
       const pool = getPool(connection);
 
+      await pool.query('SELECT 1');
+
       try {
         await initializeTable(pool, table);
       } catch (error) {


### PR DESCRIPTION
This fix is only needed because downstream packages (Postgres and MySQL2) handle closing/ending of a database connection instance that hasn't been connected successfully weirdly, they get stuck indefinitely when trying to close the connection.

By adding a `SELECT 1` after getting a connection pool, and outside of the try/catch statement we make sure it crashes for real if a connection can't be established