### PR TITLE
fix(cli): force exiting after 10 seconds should not change the exit code

### DIFF
--- a/.changeset/wicked-months-kneel.md
+++ b/.changeset/wicked-months-kneel.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/cli': patch
+---
+
+Force exiting after 10 seconds should not change the exit code, i.e. if all migrations have run successfully the exit code should be 0

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -602,5 +602,5 @@ await main(process.argv.slice(2), controller.signal);
 
 setTimeout(() => {
   console.error('Process did not exit within 10 seconds, forcing exit');
-  process.exit(1);
+  process.exit(process.exitCode);
 }, 10_000).unref();


### PR DESCRIPTION
If all migrations have been run successfully we want the exit code to be 0 even though we had to force exit the process. This is because on some platforms (e.g. Bun) all handles are not cleaned up the same as in NodeJS, so lets be forgiving.