### PR TITLE
fix(mysql): unreference all connections so that the process can exit cleanly

### DIFF
--- a/.changeset/spotty-singers-shake.md
+++ b/.changeset/spotty-singers-shake.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/mysql': patch
+---
+
+Unreference all connections automatically so that they don't hinder the process from exiting. This is especially needed in Bun environments as it seems to handle sockets differently regarding this matter than NodeJS.

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -171,6 +171,12 @@ export const createMysqlStorage = ({ table = defaultTable, connection }: MysqlSt
     async initializeStorage() {
       const pool = getPool(connection);
 
+      pool.on('connection', (connection) => {
+        // @ts-expect-error stream is not in the types but it's there
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        connection.stream.unref();
+      });
+
       await pool.query('SELECT 1');
 
       try {
@@ -267,6 +273,10 @@ export const createMysqlLoader = ({ connection }: MysqlLoaderOptions): LoaderPlu
       return async () => {
         const contents = await fs.readFile(migration.filePath, 'utf8');
         const conn = await getConnection(connection);
+
+        // @ts-expect-error the connection is not in the types but it's there
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        conn.connection.stream.unref();
 
         try {
           await conn.query(contents);


### PR DESCRIPTION
In a NodeJS environment it will just work as before, but in a Bun environment it will make the "forced exit" error message disappear and remove the 10 s waiting period when migrations are done.