### PR TITLE
fix(mysql): handle table initialization better in clustered database environments

### DIFF
--- a/.changeset/thirty-beds-fetch.md
+++ b/.changeset/thirty-beds-fetch.md
@@ -1,0 +1,5 @@
+---
+'@emigrate/mysql': patch
+---
+
+Avoid "CREATE TABLE IF NOT EXISTS" as it's too locking in a clustered database when running it concurrently


### PR DESCRIPTION
The CREATE TABLE IF NOT EXISTS yields more locks than checking if the table exists using a SELECT first before running CREATE TABLE. This makes more sense as the table usually already exists, so we optimize for the happy path.